### PR TITLE
Fix naming to support macs  🍎🚀

### DIFF
--- a/dotnet-openapi-generator/dotnet-openapi-generator.csproj
+++ b/dotnet-openapi-generator/dotnet-openapi-generator.csproj
@@ -16,13 +16,13 @@
 
 	<PropertyGroup>
 		<TargetFramework>net$(openapi-generator-version)</TargetFramework>
-		<Version>$(openapi-generator-version).0-preview.6</Version>
+		<Version>$(openapi-generator-version).0-preview.7</Version>
 		<Authors>Steven Thuriot</Authors>
 		<Copyright>$(Authors)</Copyright>
 		<PackAsTool>true</PackAsTool>
-		<ToolCommandName>openapi-generator</ToolCommandName>
+		<ToolCommandName>dotnet-openapi-generator</ToolCommandName>
 		<AssemblyName>$(ToolCommandName)</AssemblyName>
-		<PackageId>dotnet-$(ToolCommandName)</PackageId>
+		<PackageId>$(ToolCommandName)</PackageId>
 		<Product>OpenApi Generator</Product>
 		<Title>$(Product)</Title>
 		<Description>Generate C# code based on swagger documents</Description>

--- a/readme.md
+++ b/readme.md
@@ -17,17 +17,17 @@ Major and Minor version numbers always dictate the dotnet version being used.
 
 ### dotnet 5.0 generator installation
 ```bash
-dotnet tool install dotnet-openapi-generator -g --version 5.0.0-preview.6
+dotnet tool install dotnet-openapi-generator -g --version 5.0.0-preview.7
 ```
 
 ### dotnet 6.0 generator installation
 ```bash
-dotnet tool install dotnet-openapi-generator -g --version 6.0.0-preview.6
+dotnet tool install dotnet-openapi-generator -g --version 6.0.0-preview.7
 ```
 
 ### dotnet 7.0 generator installation
 ```bash
-dotnet tool install dotnet-openapi-generator -g --version 7.0.0-preview.6
+dotnet tool install dotnet-openapi-generator -g --version 7.0.0-preview.7
 ```
 
 
@@ -35,7 +35,7 @@ dotnet tool install dotnet-openapi-generator -g --version 7.0.0-preview.6
 
 ```bash
 C:\Git > dotnet openapi-generator --help
-dotnet-openapi-generator 7.0.0-preview.6
+openapi-generator 7.0.0-preview.7
 Steven Thuriot
 
   -n, --namespace                 (Default: Project name) The namespace used for the generated files

--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,8 @@ dotnet tool install dotnet-openapi-generator -g --version 7.0.0-preview.6
 ## Getting started
 
 ```bash
-C:\Git > openapi-generator --help
-openapi-generator 7.0.0-preview.6
+C:\Git > dotnet openapi-generator --help
+dotnet-openapi-generator 7.0.0-preview.6
 Steven Thuriot
 
   -n, --namespace                 (Default: Project name) The namespace used for the generated files


### PR DESCRIPTION
Changed naming to dotnet-openapi-generator. Fixes #1