### PR TITLE
Extended Enum Support

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,7 @@
 cd dotnet-openapi-generator
 
 $versions = @("5.0", "6.0", "7.0")
-$postfix = "-preview.13"
+$postfix = "-preview.14"
 
 foreach ($i in $versions) {
    Write-Host "Building for dotnet $i"

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,6 @@
 cd dotnet-openapi-generator
 
-$versions = @("5.0", "6.0", "7.0")
+$versions = @("5.0", "6.0", "7.0", "8.0")
 $postfix = "-preview.14"
 
 foreach ($i in $versions) {

--- a/dotnet-openapi-generator/Compatibility.cs
+++ b/dotnet-openapi-generator/Compatibility.cs
@@ -1,0 +1,18 @@
+﻿namespace dotnet.openapi.generator;
+internal static class Compatibility
+{
+#if !NET6_0_OR_GREATER
+    public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+    {
+        HashSet<TKey> set = new();
+
+        foreach (TSource item in source)
+        {
+            if (set.Add(keySelector(item)))
+            {
+                yield return item;
+            }
+        }
+    }
+#endif
+}

--- a/dotnet-openapi-generator/Constants.cs
+++ b/dotnet-openapi-generator/Constants.cs
@@ -22,10 +22,8 @@ internal static class Constants
     private static string GetInformationalVersion() => Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
 
 #if GENERATING_NETSTANDARD
-    public const bool GeneratingNetStandard = true;
     private static readonly Lazy<string> _productVersion = new(() => GetInformationalVersion() + " ( NetStandard )");
 #else
-    public const bool GeneratingNetStandard = false;
     private static readonly Lazy<string> _productVersion = new(GetInformationalVersion);
 #endif
 

--- a/dotnet-openapi-generator/Logger.cs
+++ b/dotnet-openapi-generator/Logger.cs
@@ -43,6 +43,8 @@ internal static class Logger
         Log(message);
     }
 
+    public static void Break() => Log(NewLine);
+
     public static void BlankLine()
     {
         if (s_canBeFancy)

--- a/dotnet-openapi-generator/Models/Extensions.cs
+++ b/dotnet-openapi-generator/Models/Extensions.cs
@@ -76,7 +76,7 @@ internal static class Extensions
 
     public static IEnumerable<string> AsUniques(this IEnumerable<string> values)
     {
-        HashSet<string> returnedValues = new();
+        HashSet<string> returnedValues = [];
 
         foreach (var value in values)
         {
@@ -94,7 +94,7 @@ internal static class Extensions
 
     public static IEnumerable<(T item, string name)> AsUniques<T>(this IEnumerable<T> values, Func<T, string> get)
     {
-        HashSet<string> returnedValues = new();
+        HashSet<string> returnedValues = [];
 
         foreach (var value in values)
         {

--- a/dotnet-openapi-generator/Models/Extensions.cs
+++ b/dotnet-openapi-generator/Models/Extensions.cs
@@ -38,15 +38,16 @@ internal static class Extensions
                      .AsSafeString(replaceDots: true, replacement: "");
     }
 
-    private static string AsSafeCSharpName(this string value, string prefix)
+    public static string AsSafeCSharpName(this string value, string prefix) => value.AsSafeCSharpName(prefix, prefix);
+    public static string AsSafeCSharpName(this string value, string keywordPrefix, string numberPrefix)
     {
         if (s_keywords.Contains(value))
         {
-            value = prefix + value;
+            value = keywordPrefix + value;
         }
         else if (char.IsNumber(value[0]))
         {
-            value = prefix + value;
+            value = numberPrefix + value;
         }
 
         return value;
@@ -134,6 +135,7 @@ internal static class Extensions
             "boolean" => "bool",
             "int32" or "integer" => "int",
             "int64" => "long",
+            "json" => "string",
             "uri" => typeof(Uri).FullName!,
             "uuid" => typeof(Guid).FullName!,
             "binary" => typeof(Stream).FullName!,

--- a/dotnet-openapi-generator/Models/Extensions.cs
+++ b/dotnet-openapi-generator/Models/Extensions.cs
@@ -4,7 +4,7 @@ namespace dotnet.openapi.generator;
 
 internal static class Extensions
 {
-    public static string AsSafeVariableName(this string value, string prefix = "@")
+    public static string AsSafeVariableName(this string value, string keywordPrefix = "@", string numberPrefix = "_")
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -15,7 +15,7 @@ internal static class Extensions
             ? value
             : value[0..1].ToLowerInvariant() + value[1..];
 
-        return result.AsSafeCSharpName(prefix);
+        return result.AsSafeCSharpName(keywordPrefix, numberPrefix);
     }
 
     public static string AsSafeClientName(this string value, string prefix = "_")

--- a/dotnet-openapi-generator/Models/Modifier.cs
+++ b/dotnet-openapi-generator/Models/Modifier.cs
@@ -5,3 +5,18 @@ public enum Modifier
     Public,
     Internal
 }
+
+public static class ModifierFastEnum
+{
+    public static string ToString(Modifier value) => value switch
+    {
+        Modifier.Public => "Public",
+        _ => throw new ArgumentException(nameof(value)),
+    };
+
+    public static Modifier FromString(string value) => value switch
+    {
+        "Public" => Modifier.Public,
+        _ => throw new ArgumentException(nameof(value)),
+    };
+}

--- a/dotnet-openapi-generator/Models/SwaggerComponentSchemas.cs
+++ b/dotnet-openapi-generator/Models/SwaggerComponentSchemas.cs
@@ -1,0 +1,45 @@
+﻿using System.Text;
+using System.Text.Json.Serialization;
+
+namespace dotnet.openapi.generator;
+
+internal class SwaggerComponentSchemas : Dictionary<string, SwaggerSchema>
+{
+    [JsonConstructor] public SwaggerComponentSchemas() { }
+
+    public SwaggerComponentSchemas(IDictionary<string, SwaggerSchema> values) : base(values) { }
+
+    public string? GenerateFastEnumToString(string type, string property)
+    {
+        if (type is null || !TryGetValue(type, out var schema))
+        {
+            return null;
+        }
+
+        if (schema.@enum is null)
+        {
+            return null;
+        }
+
+        StringBuilder builder = new(property);
+
+        builder.AppendLine(" switch")
+               .AppendLine("\t\t{");
+
+        foreach (var (name, safeName) in schema.@enum.IterateValues(schema.FlaggedEnum, schema.EnumNames))
+        {
+            builder.Append("\t\t\t")
+                   .Append(type)
+                   .Append('.')
+                   .Append(safeName)
+                   .Append(" => \"")
+                   .Append(name)
+                   .AppendLine("\",");
+        }
+
+        builder.AppendLine("\t\t\t_ => null");
+        builder.Append("\t\t}");
+
+        return builder.ToString();
+    }
+}

--- a/dotnet-openapi-generator/Models/SwaggerComponentSchemas.cs
+++ b/dotnet-openapi-generator/Models/SwaggerComponentSchemas.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using System.Text.Json.Serialization;
 
 namespace dotnet.openapi.generator;
@@ -9,16 +10,18 @@ internal class SwaggerComponentSchemas : Dictionary<string, SwaggerSchema>
 
     public SwaggerComponentSchemas(IDictionary<string, SwaggerSchema> values) : base(values) { }
 
-    public string? GenerateFastEnumToString(string type, string property)
+    public bool TryGenerateFastEnumToString(string type, string property, [NotNullWhen(true)] out string? result)
     {
         if (type is null || !TryGetValue(type, out var schema))
         {
-            return null;
+            result = null;
+            return false;
         }
 
         if (schema.@enum is null)
         {
-            return null;
+            result = null;
+            return false;
         }
 
         StringBuilder builder = new(property);
@@ -40,6 +43,7 @@ internal class SwaggerComponentSchemas : Dictionary<string, SwaggerSchema>
         builder.AppendLine("\t\t\t_ => null");
         builder.Append("\t\t}");
 
-        return builder.ToString();
+        result = builder.ToString();
+        return true;
     }
 }

--- a/dotnet-openapi-generator/Models/SwaggerComponentSchemas.cs
+++ b/dotnet-openapi-generator/Models/SwaggerComponentSchemas.cs
@@ -29,7 +29,7 @@ internal class SwaggerComponentSchemas : Dictionary<string, SwaggerSchema>
         builder.AppendLine(" switch")
                .AppendLine("\t\t{");
 
-        foreach (var (name, safeName) in schema.@enum.IterateValues(schema.FlaggedEnum, schema.EnumNames))
+        foreach (var (name, safeName) in schema.@enum.IterateValues(schema.flaggedEnum, schema.enumNames))
         {
             builder.Append("\t\t\t")
                    .Append(type)

--- a/dotnet-openapi-generator/Models/SwaggerComponents.cs
+++ b/dotnet-openapi-generator/Models/SwaggerComponents.cs
@@ -52,16 +52,24 @@ internal class SwaggerComponents
 
 namespace {@namespace}.Clients;
 
-[System.Text.Json.Serialization.JsonSourceGenerationOptions(DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull, PropertyNamingPolicy = System.Text.Json.Serialization.JsonKnownNamingPolicy.CamelCase)]
+[System.Text.Json.Serialization.JsonSourceGenerationOptions(DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull, PropertyNamingPolicy = System.Text.Json.Serialization.JsonKnownNamingPolicy.CamelCase"
+#if NET8_0_OR_GREATER
++ ", UseStringEnumConverter = true, PropertyNameCaseInsensitive = true, NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString"
+#endif
++ @")]
 {string.Join(Environment.NewLine, attributes)}
 {clientModifierValue} sealed partial class {className}JsonSerializerContext : System.Text.Json.Serialization.JsonSerializerContext
-{{
+{{"
+#if !NET8_0_OR_GREATER
+        + $@"
     static {className}JsonSerializerContext()
     {{
         s_defaultOptions.PropertyNameCaseInsensitive = true;
         s_defaultOptions.NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString;
         s_defaultOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
-    }}
+    }}"
+#endif
+        + @"
 }}";
 
                 await File.WriteAllTextAsync(Path.Combine(path, "../Clients/__JsonSerializerContext.cs"), template, token);

--- a/dotnet-openapi-generator/Models/SwaggerComponents.cs
+++ b/dotnet-openapi-generator/Models/SwaggerComponents.cs
@@ -1,10 +1,8 @@
-﻿using System.Text.Json.Serialization;
-
-namespace dotnet.openapi.generator;
+﻿namespace dotnet.openapi.generator;
 
 internal class SwaggerComponents
 {
-    public Dictionary<string, SwaggerSchema> schemas { get; set; } = default!;
+    public SwaggerComponentSchemas schemas { get; set; } = default!;
 
     public async Task Generate(string path, string @namespace, string modifier, string clientModifierValue, IEnumerable<string> usedComponents, bool treeShaking, string? jsonConstructorAttribute, string? jsonPolymorphicAttribute, string? jsonDerivedTypeAttribute, string? jsonPropertyNameAttribute, bool includeJsonSourceGenerators, bool supportRequiredProperties, CancellationToken token)
     {
@@ -22,7 +20,7 @@ internal class SwaggerComponents
 
         if (treeShaking)
         {
-            schemasToGenerate = schemasToGenerate.ToDictionary(x => x.Key.AsSafeString(), x => x.Value);
+            schemasToGenerate = new(schemasToGenerate.ToDictionary(x => x.Key.AsSafeString(), x => x.Value));
             ShakeTree(usedComponents, schemasToGenerate);
         }
 

--- a/dotnet-openapi-generator/Models/SwaggerComponents.cs
+++ b/dotnet-openapi-generator/Models/SwaggerComponents.cs
@@ -1,10 +1,12 @@
-﻿namespace dotnet.openapi.generator;
+﻿using System.Text.Json.Serialization;
+
+namespace dotnet.openapi.generator;
 
 internal class SwaggerComponents
 {
     public Dictionary<string, SwaggerSchema> schemas { get; set; } = default!;
 
-    public async Task Generate(string path, string @namespace, string modifier, string clientModifierValue, IEnumerable<string> usedComponents, bool treeShaking, string? jsonConstructorAttribute, string? jsonPolymorphicAttribute, string? jsonDerivedTypeAttribute, bool includeJsonSourceGenerators, bool supportRequiredProperties, CancellationToken token)
+    public async Task Generate(string path, string @namespace, string modifier, string clientModifierValue, IEnumerable<string> usedComponents, bool treeShaking, string? jsonConstructorAttribute, string? jsonPolymorphicAttribute, string? jsonDerivedTypeAttribute, string? jsonPropertyNameAttribute, bool includeJsonSourceGenerators, bool supportRequiredProperties, CancellationToken token)
     {
         path = Path.Combine(path, "Models");
 
@@ -30,7 +32,7 @@ internal class SwaggerComponents
         foreach (var schema in schemasToGenerate)
         {
             Logger.LogStatus(++i, schemasToGenerate.Count, schema.Key);
-            await schema.Value.Generate(path, @namespace, modifier, schema.Key, jsonConstructorAttribute, jsonPolymorphicAttribute, jsonDerivedTypeAttribute, supportRequiredProperties, schemasToGenerate, token);
+            await schema.Value.Generate(path, @namespace, modifier, schema.Key, jsonConstructorAttribute, jsonPolymorphicAttribute, jsonDerivedTypeAttribute, jsonPropertyNameAttribute, supportRequiredProperties, schemasToGenerate, token);
         }
 
         Logger.BlankLine();

--- a/dotnet-openapi-generator/Models/SwaggerComponents.cs
+++ b/dotnet-openapi-generator/Models/SwaggerComponents.cs
@@ -56,7 +56,7 @@ namespace {@namespace}.Clients;
 #if NET8_0_OR_GREATER
 + ", UseStringEnumConverter = true, PropertyNameCaseInsensitive = true, NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString"
 #endif
-+ @")]
++ $@")]
 {string.Join(Environment.NewLine, attributes)}
 {clientModifierValue} sealed partial class {className}JsonSerializerContext : System.Text.Json.Serialization.JsonSerializerContext
 {{"
@@ -69,7 +69,7 @@ namespace {@namespace}.Clients;
         s_defaultOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
     }}"
 #endif
-        + @"
+        + $@"
 }}";
 
                 await File.WriteAllTextAsync(Path.Combine(path, "../Clients/__JsonSerializerContext.cs"), template, token);

--- a/dotnet-openapi-generator/Models/SwaggerDocument.cs
+++ b/dotnet-openapi-generator/Models/SwaggerDocument.cs
@@ -27,13 +27,14 @@ internal class SwaggerDocument
         bool treeShaking = options.TreeShaking && (excludeObsolete || filter is not null);
         bool includeJsonSourceGenerators = options.IncludeJsonSourceGenerators;
         bool supportRequiredProperties = options.SupportRequiredProperties;
+        string? jsonPropertyNameAttribute = options.JsonPropertyNameAttribute;
 
         string modifierValue = options.Modifier.ToString().ToLowerInvariant();
         string clientModifierValue = options.ClientModifier?.ToString().ToLowerInvariant() ?? modifierValue;
 
         IEnumerable<string> usedComponents = await paths.Generate(path, @namespace, modifierValue, excludeObsolete, filter, includeInterfaces, clientModifierValue, stringBuilderPoolSize, options.OAuthType, includeJsonSourceGenerators, token);
 
-        await components.Generate(path, @namespace, modifierValue, clientModifierValue, usedComponents, treeShaking, jsonConstructorAttribute, jsonPolymorphicAttribute, jsonDerivedTypeAttribute, includeJsonSourceGenerators, supportRequiredProperties, token);
+        await components.Generate(path, @namespace, modifierValue, clientModifierValue, usedComponents, treeShaking, jsonConstructorAttribute, jsonPolymorphicAttribute, jsonDerivedTypeAttribute, jsonPropertyNameAttribute, includeJsonSourceGenerators, supportRequiredProperties, token);
 
         if (!options.ExcludeProject)
         {

--- a/dotnet-openapi-generator/Models/SwaggerDocument.cs
+++ b/dotnet-openapi-generator/Models/SwaggerDocument.cs
@@ -32,7 +32,7 @@ internal class SwaggerDocument
         string modifierValue = options.Modifier.ToString().ToLowerInvariant();
         string clientModifierValue = options.ClientModifier?.ToString().ToLowerInvariant() ?? modifierValue;
 
-        IEnumerable<string> usedComponents = await paths.Generate(path, @namespace, modifierValue, excludeObsolete, filter, includeInterfaces, clientModifierValue, stringBuilderPoolSize, options.OAuthType, includeJsonSourceGenerators, token);
+        IEnumerable<string> usedComponents = await paths.Generate(path, @namespace, modifierValue, excludeObsolete, filter, includeInterfaces, clientModifierValue, stringBuilderPoolSize, options.OAuthType, includeJsonSourceGenerators, components.schemas, token);
 
         await components.Generate(path, @namespace, modifierValue, clientModifierValue, usedComponents, treeShaking, jsonConstructorAttribute, jsonPolymorphicAttribute, jsonDerivedTypeAttribute, jsonPropertyNameAttribute, includeJsonSourceGenerators, supportRequiredProperties, token);
 

--- a/dotnet-openapi-generator/Models/SwaggerDocument.cs
+++ b/dotnet-openapi-generator/Models/SwaggerDocument.cs
@@ -74,14 +74,13 @@ internal class SwaggerDocument
         }
 
         string targetframework = "";
-#pragma warning disable CS0162 // Unreachable code detected
-        if (Constants.GeneratingNetStandard)
+#if GENERATING_NETSTANDARD
         {
             additionalIncludes += $@"
     <PackageReference Include=""System.Text.Json"" Version=""[6.*,)"" />";
             targetframework = "standard";
         }
-#pragma warning restore CS0162 // Unreachable code detected
+#endif
 
         return File.WriteAllTextAsync(file, @$"<Project Sdk=""Microsoft.NET.Sdk"">
 
@@ -146,7 +145,7 @@ internal class __TokenCache : ITokenCache
             }
         }
 
-        return File.WriteAllTextAsync(file, Constants.Header + @$"namespace {options.Namespace}.Clients;{additionalHelpers}
+        return File.WriteAllTextAsync(file, Constants.Header + $@"namespace {options.Namespace}.Clients;{additionalHelpers}
 
 [System.CodeDom.Compiler.GeneratedCode(""dotnet-openapi-generator"", ""{Constants.ProductVersion}"")]
 [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/dotnet-openapi-generator/Models/SwaggerPathBase.cs
+++ b/dotnet-openapi-generator/Models/SwaggerPathBase.cs
@@ -66,7 +66,7 @@ internal abstract class SwaggerPathBase
         var queryContent = "";
         if (queryParams.Count > 0)
         {
-            queryContent += "__QueryBuilder __my_queryBuilder = new();" + Environment.NewLine + string.Concat(queryParams.Select(x => $"        __my_queryBuilder.AddParameter({x.name}, \"{x.name.TrimStart('@')}\");" + Environment.NewLine)) + Environment.NewLine + "        ";
+            queryContent += "__QueryBuilder __my_queryBuilder = new();" + Environment.NewLine + string.Concat(queryParams.Select(x => $"        __my_queryBuilder.AddParameter({x.name.AsSafeString()}, \"{x.name.TrimStart('@')}\");" + Environment.NewLine)) + Environment.NewLine + "        ";
             apiPath += "{__my_queryBuilder}";
         }
 

--- a/dotnet-openapi-generator/Models/SwaggerPathBase.cs
+++ b/dotnet-openapi-generator/Models/SwaggerPathBase.cs
@@ -144,7 +144,7 @@ internal abstract class SwaggerPathBase
         if (requestBody?.content?.multipartformdata is not null)
         {
             var contents = "";
-            List<string> contentNames = new();
+            List<string> contentNames = [];
 
             foreach (var x in requestBody.content.multipartformdata.schema.IterateProperties().Select(x => x.Value)
                                             .Select(x => x.ResolveType()!)

--- a/dotnet-openapi-generator/Models/SwaggerPathBase.cs
+++ b/dotnet-openapi-generator/Models/SwaggerPathBase.cs
@@ -90,6 +90,15 @@ internal abstract class SwaggerPathBase
                     safeString = "\"\" + " + safeString;
                 }
 
+                //TODO: if enum
+                // switch
+                //{
+                //    enum.Value => "Value",
+                //    _ => null
+                //
+                //}
+
+
                 headersToAdd += $@"
         if ({header.name.AsSafeString()} != default)
         {{

--- a/dotnet-openapi-generator/Models/SwaggerPathBase.cs
+++ b/dotnet-openapi-generator/Models/SwaggerPathBase.cs
@@ -73,9 +73,12 @@ internal abstract class SwaggerPathBase
             {
                 var syntax = x.name.AsSafeString();
 
-                var fastToString = componentSchemas.GenerateFastEnumToString(x.GetComponentType()!, syntax);
+                if (componentSchemas.TryGenerateFastEnumToString(x.GetComponentType()!, syntax, out var fastToString))
+                {
+                    return fastToString;
+                }
 
-                return fastToString ?? syntax;
+                return syntax;
             }
         }
 
@@ -99,13 +102,9 @@ internal abstract class SwaggerPathBase
                     safeString = "\"\" + " + safeString;
                 }
 
-                if (header.schema.@ref is not null)
+                if (header.schema.@ref is not null && componentSchemas.TryGenerateFastEnumToString(type, safeString, out var fastToString))
                 {
-                    var fastToStringResult = componentSchemas.GenerateFastEnumToString(type, safeString);
-                    if (fastToStringResult is not null)
-                    {
-                        safeString = fastToStringResult;
-                    }
+                    safeString = fastToString;
                 }
 
                 headersToAdd += $@"

--- a/dotnet-openapi-generator/Models/SwaggerPathParameter.cs
+++ b/dotnet-openapi-generator/Models/SwaggerPathParameter.cs
@@ -25,7 +25,7 @@ internal class SwaggerPathParameter
                 myName += " = " + @default.ToString()!.ToLowerInvariant();
             }
         }
-        else if (@in == "query" || schema.nullable)
+        else if (schema.nullable || (@in == "query" && !required))
         {
             myName += " = default";
             if (!type!.EndsWith('?'))

--- a/dotnet-openapi-generator/Models/SwaggerPathRequestBodyContent.cs
+++ b/dotnet-openapi-generator/Models/SwaggerPathRequestBodyContent.cs
@@ -5,6 +5,9 @@ internal class SwaggerPathRequestBodyContent
     [System.Text.Json.Serialization.JsonPropertyName("application/json")]
     public SwaggerPathRequestBodyContentJson? applicationjson { get; set; }
 
+    [System.Text.Json.Serialization.JsonPropertyName("application/vnd.api+json")]
+    public SwaggerPathRequestBodyContentJson? applicationjsonapi { get; set; }
+
     [System.Text.Json.Serialization.JsonPropertyName("multipart/form-data")]
     public SwaggerPathRequestBodyContentMultiform? multipartformdata { get; set; }
 
@@ -15,25 +18,22 @@ internal class SwaggerPathRequestBodyContent
     {
         if (multipartformdata is not null)
         {
-            var result = "";
-
-            foreach (var item in multipartformdata.schema.IterateProperties())
-            {
-                var type = item.Value.ResolveType()!;
-                result += $"{type} @{(type[0..1].ToLowerInvariant() + type[1..]).AsSafeString()}, ";
-            }
-
-            return result;
+            return multipartformdata.GetBody();
         }
 
         if (octetstream is not null)
         {
-            return (octetstream.schema.ResolveType() ?? "object") + " body, ";
+            return octetstream.GetBody();
         }
 
         if (applicationjson is not null)
         {
-            return (applicationjson.schema.ResolveType() ?? "object") + " body, ";
+            return applicationjson.GetBody();
+        }
+
+        if (applicationjsonapi is not null)
+        {
+            return applicationjsonapi.GetBody();
         }
 
         return "";
@@ -43,17 +43,22 @@ internal class SwaggerPathRequestBodyContent
     {
         if (multipartformdata is not null)
         {
-            return typeof(Stream).FullName!;
+            return multipartformdata.ResolveType();
         }
 
         if (octetstream is not null)
         {
-            return octetstream.schema.ResolveType() ?? "object";
+            return octetstream.ResolveType();
         }
 
         if (applicationjson is not null)
         {
-            return applicationjson.schema.ResolveType() ?? "object";
+            return applicationjson.ResolveType();
+        }
+
+        if (applicationjsonapi is not null)
+        {
+            return applicationjsonapi.ResolveType();
         }
 
         return "";

--- a/dotnet-openapi-generator/Models/SwaggerPathRequestBodyContentJson.cs
+++ b/dotnet-openapi-generator/Models/SwaggerPathRequestBodyContentJson.cs
@@ -3,4 +3,14 @@
 internal class SwaggerPathRequestBodyContentJson
 {
     public SwaggerSchemaProperty schema { get; set; } = default!;
+
+    public string GetBody()
+    {
+        return (schema.ResolveType() ?? "object") + " body, ";
+    }
+
+    public string ResolveType()
+    {
+        return schema.ResolveType() ?? "object";
+    }
 }

--- a/dotnet-openapi-generator/Models/SwaggerPathRequestBodyContentMultiform.cs
+++ b/dotnet-openapi-generator/Models/SwaggerPathRequestBodyContentMultiform.cs
@@ -4,4 +4,21 @@ internal class SwaggerPathRequestBodyContentMultiform
 {
     public SwaggerPathRequestBodyContentMultiformSchema schema { get; set; } = default!;
 
+    public string GetBody()
+    {
+        var result = "";
+
+        foreach (var item in schema.IterateProperties())
+        {
+            var type = item.Value.ResolveType()!;
+            result += $"{type} @{(type[0..1].ToLowerInvariant() + type[1..]).AsSafeString()}, ";
+        }
+
+        return result;
+    }
+
+    public string ResolveType()
+    {
+        return typeof(Stream).FullName!;
+    }
 }

--- a/dotnet-openapi-generator/Models/SwaggerPathRequestBodyContentOctetStream.cs
+++ b/dotnet-openapi-generator/Models/SwaggerPathRequestBodyContentOctetStream.cs
@@ -3,4 +3,14 @@
 internal class SwaggerPathRequestBodyContentOctetStream
 {
     public SwaggerSchemaProperty schema { get; set; } = default!;
+
+    public string GetBody()
+    {
+        return (schema.ResolveType() ?? "object") + " body, ";
+    }
+
+    public string ResolveType()
+    {
+        return schema.ResolveType() ?? "object";
+    }
 }

--- a/dotnet-openapi-generator/Models/SwaggerSchema.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchema.cs
@@ -7,10 +7,10 @@ internal class SwaggerSchema
     public SwaggerSchemaEnum? @enum { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("flagged-enum")]
-    public SwaggerSchemaFlaggedEnum? FlaggedEnum { get; set; }
+    public SwaggerSchemaFlaggedEnum? flaggedEnum { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("x-enumNames")]
-    public List<string>? EnumNames { get; set; }
+    public List<string>? enumNames { get; set; }
 
     public SwaggerSchemaProperties? properties { get; set; }
 
@@ -60,7 +60,7 @@ internal class SwaggerSchema
             return null;
         }
 
-        HashSet<(string key, SwaggerSchemaProperty value)> baseProperties = new();
+        HashSet<(string key, SwaggerSchemaProperty value)> baseProperties = [];
         HashSet<(string key, SwaggerSchemaProperty value)> requiredProperties = GetRequiredProperties();
 
         if (allOf is not null)
@@ -124,11 +124,11 @@ internal class SwaggerSchema
 ";
     }
 
-    private HashSet<(string key, SwaggerSchemaProperty value)> GetRequiredProperties() => IterateProperties()?.Where(x => x.Value.required.GetValueOrDefault() || !x.Value.nullable).ToHashSet() ?? new(0);
+    private HashSet<(string key, SwaggerSchemaProperty value)> GetRequiredProperties() => IterateProperties()?.Where(x => !x.Value.nullable /*|| x.Value.required.GetValueOrDefault()*/).ToHashSet() ?? new(0);
 
     private string GetInheritance()
     {
-        HashSet<string> toImplement = new();
+        HashSet<string> toImplement = [];
 
         if (allOf is not null)
         {
@@ -156,7 +156,7 @@ internal class SwaggerSchema
 
     public string? GetBody(string name, bool supportRequiredProperties, string? jsonPropertyNameAttribute, SwaggerComponentSchemas schemas, string modifier)
     {
-        return @enum?.GetBody(name, FlaggedEnum, EnumNames, modifier) ?? properties?.GetBody(allOf, supportRequiredProperties, jsonPropertyNameAttribute, schemas, discriminator?.propertyName);
+        return @enum?.GetBody(name, flaggedEnum, enumNames, modifier) ?? properties?.GetBody(allOf, supportRequiredProperties, jsonPropertyNameAttribute, schemas, discriminator?.propertyName);
     }
 
     public Task Generate(string path, string @namespace, string modifier, string name, string? jsonConstructorAttribute, string? jsonPolymorphicAttribute, string? jsonDerivedTypeAttribute, string? jsonPropertyNameAttribute, bool supportRequiredProperties, SwaggerComponentSchemas schemas, CancellationToken token)
@@ -188,7 +188,7 @@ internal class SwaggerSchema
 [System.CodeDom.Compiler.GeneratedCode(""dotnet-openapi-generator"", ""{Constants.ProductVersion}"")]{attributes}
 {(@enum is null
     ? "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]" + Environment.NewLine
-    : (FlaggedEnum is not null
+    : (flaggedEnum is not null
         ? "[System.Flags]" + Environment.NewLine
         : "")
         + "[System.Text.Json.Serialization.JsonConverter(typeof("+name+@"EnumConverter))]

--- a/dotnet-openapi-generator/Models/SwaggerSchema.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchema.cs
@@ -154,12 +154,12 @@ internal class SwaggerSchema
         return "";
     }
 
-    public string? GetBody(string name, bool supportRequiredProperties, string? jsonPropertyNameAttribute, IReadOnlyDictionary<string, SwaggerSchema> schemas)
+    public string? GetBody(string name, bool supportRequiredProperties, string? jsonPropertyNameAttribute, SwaggerComponentSchemas schemas)
     {
         return @enum?.GetBody(name, FlaggedEnum, EnumNames) ?? properties?.GetBody(allOf, supportRequiredProperties, jsonPropertyNameAttribute, schemas, discriminator?.propertyName);
     }
 
-    public Task Generate(string path, string @namespace, string modifier, string name, string? jsonConstructorAttribute, string? jsonPolymorphicAttribute, string? jsonDerivedTypeAttribute, string? jsonPropertyNameAttribute, bool supportRequiredProperties, IReadOnlyDictionary<string, SwaggerSchema> schemas, CancellationToken token)
+    public Task Generate(string path, string @namespace, string modifier, string name, string? jsonConstructorAttribute, string? jsonPolymorphicAttribute, string? jsonDerivedTypeAttribute, string? jsonPropertyNameAttribute, bool supportRequiredProperties, SwaggerComponentSchemas schemas, CancellationToken token)
     {
         name = name.AsSafeString();
         var fileName = Path.Combine(path, name + ".cs");

--- a/dotnet-openapi-generator/Models/SwaggerSchema.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchema.cs
@@ -147,9 +147,9 @@ internal class SwaggerSchema
         return "";
     }
 
-    public string? GetBody(bool supportRequiredProperties, IReadOnlyDictionary<string, SwaggerSchema> schemas)
+    public string? GetBody(string name, bool supportRequiredProperties, IReadOnlyDictionary<string, SwaggerSchema> schemas)
     {
-        return @enum?.GetBody(FlaggedEnum, EnumNames) ?? properties?.GetBody(allOf, supportRequiredProperties, schemas, discriminator?.propertyName);
+        return @enum?.GetBody(name, FlaggedEnum, EnumNames) ?? properties?.GetBody(allOf, supportRequiredProperties, schemas, discriminator?.propertyName);
     }
 
     public Task Generate(string path, string @namespace, string modifier, string name, string? jsonConstructorAttribute, string? jsonPolymorphicAttribute, string? jsonDerivedTypeAttribute, bool supportRequiredProperties, IReadOnlyDictionary<string, SwaggerSchema> schemas, CancellationToken token)
@@ -185,7 +185,7 @@ internal class SwaggerSchema
         ? "[System.Flags]" + Environment.NewLine
         : "")}{modifier} {GetDefinitionType(name, schemas.Values)} {name}{GetInheritance()}
 {{{GetCtor(name, jsonConstructorAttribute, supportRequiredProperties, schemas)}
-{GetBody(supportRequiredProperties, schemas)}
+{GetBody(name, supportRequiredProperties, schemas)}
 }}
 ";
         return File.WriteAllTextAsync(fileName, template, token);

--- a/dotnet-openapi-generator/Models/SwaggerSchema.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchema.cs
@@ -188,9 +188,11 @@ internal class SwaggerSchema
 [System.CodeDom.Compiler.GeneratedCode(""dotnet-openapi-generator"", ""{Constants.ProductVersion}"")]{attributes}
 {(@enum is null
     ? "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]" + Environment.NewLine
-    : FlaggedEnum is not null
+    : (FlaggedEnum is not null
         ? "[System.Flags]" + Environment.NewLine
-        : "")}{modifier} {GetDefinitionType(name, schemas.Values)} {name}{GetInheritance()}
+        : "")
+        + "[System.Text.Json.Serialization.JsonConverter(typeof("+name+@"EnumConverter))]
+")}{modifier} {GetDefinitionType(name, schemas.Values)} {name}{GetInheritance()}
 {{{GetCtor(name, jsonConstructorAttribute, supportRequiredProperties, schemas)}
 {GetBody(name, supportRequiredProperties, jsonPropertyNameAttribute, schemas, modifier)}
 }}

--- a/dotnet-openapi-generator/Models/SwaggerSchema.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchema.cs
@@ -154,9 +154,9 @@ internal class SwaggerSchema
         return "";
     }
 
-    public string? GetBody(string name, bool supportRequiredProperties, string? jsonPropertyNameAttribute, SwaggerComponentSchemas schemas)
+    public string? GetBody(string name, bool supportRequiredProperties, string? jsonPropertyNameAttribute, SwaggerComponentSchemas schemas, string modifier)
     {
-        return @enum?.GetBody(name, FlaggedEnum, EnumNames) ?? properties?.GetBody(allOf, supportRequiredProperties, jsonPropertyNameAttribute, schemas, discriminator?.propertyName);
+        return @enum?.GetBody(name, FlaggedEnum, EnumNames, modifier) ?? properties?.GetBody(allOf, supportRequiredProperties, jsonPropertyNameAttribute, schemas, discriminator?.propertyName);
     }
 
     public Task Generate(string path, string @namespace, string modifier, string name, string? jsonConstructorAttribute, string? jsonPolymorphicAttribute, string? jsonDerivedTypeAttribute, string? jsonPropertyNameAttribute, bool supportRequiredProperties, SwaggerComponentSchemas schemas, CancellationToken token)
@@ -192,7 +192,7 @@ internal class SwaggerSchema
         ? "[System.Flags]" + Environment.NewLine
         : "")}{modifier} {GetDefinitionType(name, schemas.Values)} {name}{GetInheritance()}
 {{{GetCtor(name, jsonConstructorAttribute, supportRequiredProperties, schemas)}
-{GetBody(name, supportRequiredProperties, jsonPropertyNameAttribute, schemas)}
+{GetBody(name, supportRequiredProperties, jsonPropertyNameAttribute, schemas, modifier)}
 }}
 ";
         return File.WriteAllTextAsync(fileName, template, token);

--- a/dotnet-openapi-generator/Models/SwaggerSchema.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchema.cs
@@ -82,7 +82,18 @@ internal class SwaggerSchema
         }
 
         var parameters = baseProperties.Union(requiredProperties).Select(x => x.value.ResolveType() + " " + x.key.AsSafeVariableName());
-        var assignements = requiredProperties.Select(x => x.key[0..1].ToUpperInvariant() + x.key[1..] + " = " + x.key.AsSafeVariableName() + ";");
+        var assignements = requiredProperties.Select(x => 
+        {
+             var assignee = x.key[0..1].ToUpperInvariant() + x.key[1..];
+             var assignment =  x.key.AsSafeVariableName();
+             
+             if (assignee == assignment)
+             {
+                assignee = "this." + assignee;
+             }
+
+             return assignee + " = " + assignment + ";";
+        });
 
         var requiredCtorAttributes = "";
         var shouldOmitDefaultCtor = string.IsNullOrWhiteSpace(jsonConstructorAttribute);

--- a/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
@@ -1,9 +1,47 @@
 ﻿using System.Text;
+using System.Xml;
 
 namespace dotnet.openapi.generator;
 
 internal class SwaggerSchemaEnum : List<object>
 {
+    public IEnumerable<(string name, string safeName)> IterateValues(SwaggerSchemaFlaggedEnum? flaggedEnum, List<string>? enumNames)
+    {
+        HashSet<string> unique = new(Count);
+
+        string name, safeName;
+
+        for (int i = 0; i < Count; i++)
+        {
+            var valueObject = this[i];
+
+            if (valueObject is null)
+            {
+                //Some documents that define the enum as nullable, also include the null value.
+                //This is handled differently in dotnet and should be skipped here.
+                continue;
+            }
+
+            if (enumNames is not null)
+            {
+                name = enumNames[i];
+            }
+            else
+            {
+                name = valueObject.ToString() ?? "";
+            }
+
+            safeName = name.AsSafeString().AsSafeCSharpName("@", "_");
+
+            if (!unique.Add(safeName))
+            {
+                continue;
+            }
+
+            yield return (name, safeName);
+        }
+    }
+
     public string GetBody(string enumName, SwaggerSchemaFlaggedEnum? flaggedEnum, List<string>? enumNames)
     {
         HashSet<string> unique = new(Count);

--- a/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
@@ -49,7 +49,11 @@ internal class SwaggerSchemaEnum : List<object>
 
                 name = $@"[System.Runtime.Serialization.EnumMember(Value = ""{name}"")]{safeName}";
             }
-            
+            else
+            {
+                name = safeName;
+            }
+
             if (!unique.Add(name))
             {
                 continue;

--- a/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
@@ -37,10 +37,7 @@ internal class SwaggerSchemaEnum : List<object>
                 name = value.ToString() ?? "";
             }
 
-            if (char.IsDigit(name[0]))
-            {
-                name = "_" + name;
-            }
+            name = name.AsSafeCSharpName("@", "_");
 
             if (!unique.Add(name))
             {

--- a/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
@@ -37,8 +37,6 @@ internal class SwaggerSchemaEnum : List<object>
                 name = value.ToString() ?? "";
             }
 
-            name = name.AsSafeString();
-
             if (char.IsDigit(name[0]))
             {
                 name = "_" + name;

--- a/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
@@ -45,7 +45,7 @@ internal class SwaggerSchemaEnum : List<object>
     record struct FastEnumValue(string Name, string Value);
     public string GetBody(string enumName, SwaggerSchemaFlaggedEnum? flaggedEnum, List<string>? enumNames, string modifier)
     {
-        List<FastEnumValue> fastEnumValues = new();
+        List<FastEnumValue> fastEnumValues = [];
 
         HashSet<string> unique = new(Count);
 

--- a/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
@@ -37,8 +37,13 @@ internal class SwaggerSchemaEnum : List<object>
                 name = value.ToString() ?? "";
             }
 
-            name = name.AsSafeCSharpName("@", "_");
+            //var safeName = name.AsSafeString().AsSafeCSharpName("@", "_");
 
+            //if (safeName != name)
+            //{
+                //name = $@"[System.Runtime.Serialization.EnumMember(Value = ""{name}"")]{safeName}";
+            //}
+            
             if (!unique.Add(name))
             {
                 continue;

--- a/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
@@ -4,7 +4,7 @@ namespace dotnet.openapi.generator;
 
 internal class SwaggerSchemaEnum : List<object>
 {
-    public string GetBody(SwaggerSchemaFlaggedEnum? flaggedEnum, List<string>? enumNames)
+    public string GetBody(string enumName, SwaggerSchemaFlaggedEnum? flaggedEnum, List<string>? enumNames)
     {
         HashSet<string> unique = new(Count);
 
@@ -37,12 +37,18 @@ internal class SwaggerSchemaEnum : List<object>
                 name = value.ToString() ?? "";
             }
 
-            //var safeName = name.AsSafeString().AsSafeCSharpName("@", "_");
+            var safeName = name.AsSafeString().AsSafeCSharpName("@", "_");
 
-            //if (safeName != name)
-            //{
-                //name = $@"[System.Runtime.Serialization.EnumMember(Value = ""{name}"")]{safeName}";
-            //}
+            if (safeName.TrimStart('@') != name)
+            {
+                Logger.Break();
+                Logger.LogWarning($"Enum \'{enumName}\' has a value that's not supported: \'{name}\' --> \'{safeName}\'.");
+                Logger.LogWarning("\tThis has been marked with an EnumMember attribute.");
+                Logger.LogWarning("\tPlease manually add the needed serialization support to your ClientOptions.");
+                Logger.Break();
+
+                name = $@"[System.Runtime.Serialization.EnumMember(Value = ""{name}"")]{safeName}";
+            }
             
             if (!unique.Add(name))
             {

--- a/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaEnum.cs
@@ -16,6 +16,13 @@ internal class SwaggerSchemaEnum : List<object>
             string name;
             var value = this[i];
 
+            if (value is null)
+            {
+                //Some documents that define the enum as nullable, also include the null value.
+                //This is handled differently in dotnet and should be skipped here.
+                continue;
+            }
+
             if (enumNames is not null)
             {
                 name = enumNames[i];
@@ -30,7 +37,9 @@ internal class SwaggerSchemaEnum : List<object>
                 name = value.ToString() ?? "";
             }
 
-            if (Char.IsDigit(name[0]))
+            name = name.AsSafeString();
+
+            if (char.IsDigit(name[0]))
             {
                 name = "_" + name;
             }

--- a/dotnet-openapi-generator/Models/SwaggerSchemaProperties.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaProperties.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.Json.Serialization;
 
 namespace dotnet.openapi.generator;
 
@@ -15,13 +16,13 @@ internal class SwaggerSchemaProperties : Dictionary<string, SwaggerSchemaPropert
         }
     }
 
-    public string GetBody(SwaggerAllOfs? allOf, bool supportRequiredProperties, IReadOnlyDictionary<string, SwaggerSchema> schemas, string? exclusion)
+    public string GetBody(SwaggerAllOfs? allOf, bool supportRequiredProperties, string? jsonPropertyNameAttribute, IReadOnlyDictionary<string, SwaggerSchema> schemas, string? exclusion)
     {
         StringBuilder builder = new();
 
         foreach (var item in Iterate(exclusion))
         {
-            builder.Append('\t').AppendLine(item.Value.GetBody(item.Key, supportRequiredProperties));
+            builder.Append('\t').AppendLine(item.Value.GetBody(item.Key, supportRequiredProperties, jsonPropertyNameAttribute));
         }
 
         builder.AppendLine()
@@ -41,8 +42,14 @@ internal class SwaggerSchemaProperties : Dictionary<string, SwaggerSchemaPropert
                 builder.Append('\t').Append('\t')
                        .Append("yield return (\"")
                        .Append(item)
-                       .Append("\", ")
-                       .Append(item[0..1].ToUpperInvariant()).Append(item[1..])
+                       .Append("\", ");
+
+                if (char.IsDigit(item[0]))
+                {
+                    builder.Append('_');
+                }
+
+                builder.Append(item[0..1].ToUpperInvariant()).Append(item[1..])
                        .AppendLine(");");
             }
         }

--- a/dotnet-openapi-generator/Models/SwaggerSchemaProperties.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaProperties.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection.PortableExecutable;
-using System.Text;
-using System.Text.Json.Serialization;
+﻿using System.Text;
 
 namespace dotnet.openapi.generator;
 

--- a/dotnet-openapi-generator/Models/SwaggerSchemaProperties.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaProperties.cs
@@ -49,8 +49,17 @@ internal class SwaggerSchemaProperties : Dictionary<string, SwaggerSchemaPropert
                     builder.Append('_');
                 }
 
-                builder.Append(item[0..1].ToUpperInvariant()).Append(item[1..])
-                       .AppendLine(");");
+                builder.Append(item[0..1].ToUpperInvariant()).Append(item[1..]);
+
+                //TODO: if enum
+                // switch
+                //{
+                //    enum.Value => "Value",
+			    //    _ => null
+                //
+                //}
+
+                builder.AppendLine(");");
             }
         }
 

--- a/dotnet-openapi-generator/Models/SwaggerSchemaProperties.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaProperties.cs
@@ -53,8 +53,14 @@ internal class SwaggerSchemaProperties : Dictionary<string, SwaggerSchemaPropert
 
                 if (property.@ref is not null)
                 {
-                    var result = schemas.GenerateFastEnumToString(property.ResolveType()!, propertyName);
-                    builder.Append(result ?? propertyName);
+                    if (schemas.TryGenerateFastEnumToString(property.ResolveType()!, propertyName, out var result))
+                    {
+                        builder.Append(result);
+                    }
+                    else
+                    {
+                        builder.Append(propertyName);
+                    }
                 }
                 else
                 {

--- a/dotnet-openapi-generator/Models/SwaggerSchemaProperty.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaProperty.cs
@@ -15,9 +15,20 @@ internal class SwaggerSchemaProperty
     public SwaggerSchemaPropertyAdditionalProperties? additionalProperties { get; set; }
     public System.Text.Json.JsonElement? items { get; set; }
 
-    public string GetBody(string name, bool supportRequiredProperties)
+    public string GetBody(string name, bool supportRequiredProperties, string? jsonPropertyNameAttribute)
     {
-        StringBuilder builder = new("public ");
+        StringBuilder builder = new();
+
+        bool startsWithDigit = char.IsDigit(name[0]);
+
+        if (startsWithDigit && jsonPropertyNameAttribute is not null)
+        {
+            builder.Append('[')
+                   .Append(jsonPropertyNameAttribute.Replace("{name}", name))
+                   .Append(']');
+        }
+
+        builder.Append("public ");
 
         if (supportRequiredProperties && (!nullable || required.GetValueOrDefault()))
         {
@@ -31,8 +42,14 @@ internal class SwaggerSchemaProperty
             builder.Append('?');
         }
 
-        builder.Append(' ')
-               .Append(name[0..1].ToUpperInvariant())
+        builder.Append(' ');
+
+        if (char.IsDigit(name[0]))
+        {
+            builder.Append('_');
+        }
+
+        builder.Append(name[0..1].ToUpperInvariant())
                .Append(name[1..])
                .Append(" { get; set; }");
 

--- a/dotnet-openapi-generator/Models/SwaggerSchemaProperty.cs
+++ b/dotnet-openapi-generator/Models/SwaggerSchemaProperty.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text;
-using System.Text.Json;
 
 namespace dotnet.openapi.generator;
 
@@ -11,7 +10,7 @@ internal class SwaggerSchemaProperty
     public string? format { get; set; }
     public object? @default { get; set; }
     public bool nullable { get; set; }
-    public bool? required { get; set; }
+    //public bool? required { get; set; }
     public SwaggerSchemaPropertyAdditionalProperties? additionalProperties { get; set; }
     public System.Text.Json.JsonElement? items { get; set; }
 
@@ -30,7 +29,7 @@ internal class SwaggerSchemaProperty
 
         builder.Append("public ");
 
-        if (supportRequiredProperties && (!nullable || required.GetValueOrDefault()))
+        if (supportRequiredProperties && (!nullable /*|| required.GetValueOrDefault()*/))
         {
             builder.Append("required ");
         }

--- a/dotnet-openapi-generator/Options.cs
+++ b/dotnet-openapi-generator/Options.cs
@@ -41,6 +41,9 @@ public class Options
     [Option("json-derived-type-attribute", Required = false, HelpText = "Json Derived Type Attribute. Marks the derived types of the generated types using the specified attribute. {type} and {value} are used as a template placeholders", Default = "System.Text.Json.Serialization.JsonDerivedType(typeof({type}), typeDiscriminator: \"{value}\")")]
     public string? JsonDerivedTypeAttribute { get; set; }
 
+    [Option("json-property-name-attribute", Required = false, HelpText = "Json Property Name Attribute. Some property names are not valid in C#. This will make sure serialization works out. {name} is used as a template placeholder", Default = "System.Text.Json.Serialization.JsonPropertyName(\"{name}\")")]
+    public string? JsonPropertyNameAttribute { get; set; }
+
 #if NET7_0_OR_GREATER
     [Option('j', "json-source-generators", Required = false, HelpText = "Include dotnet 7.0+ Json Source Generators", Default = false)]
 #endif

--- a/dotnet-openapi-generator/Options.cs
+++ b/dotnet-openapi-generator/Options.cs
@@ -38,7 +38,7 @@ public class Options
     [Option("json-polymorphic-attribute", Required = false, HelpText = "Json Polymorphic Attribute. Marks the generated types as polymorphic using the specified attribute. {name} is used as a template placeholder", Default = "System.Text.Json.Serialization.JsonPolymorphic(TypeDiscriminatorPropertyName = \"{name}\")")]
     public string? JsonPolymorphicAttribute { get; set; }
 
-    [Option("json-derived-type-attribute", Required = false, HelpText = "Json Derived Type Attribute. Marks the derived types of the generated types using the specified attribute. {type} and {value} are used as a template placeholders", Default = "System.Text.Json.Serialization.JsonDerivedType(typeof({type}), typeDiscriminator: \"{value}\")")]
+    [Option("json-derived-type-attribute", Required = false, HelpText = "Json Derived Type Attribute. Marks the derived types of the generated types using the specified attribute. {type} and {value} are used as template placeholders", Default = "System.Text.Json.Serialization.JsonDerivedType(typeof({type}), typeDiscriminator: \"{value}\")")]
     public string? JsonDerivedTypeAttribute { get; set; }
 
     [Option("json-property-name-attribute", Required = false, HelpText = "Json Property Name Attribute. Some property names are not valid in C#. This will make sure serialization works out. {name} is used as a template placeholder", Default = "System.Text.Json.Serialization.JsonPropertyName(\"{name}\")")]

--- a/dotnet-openapi-generator/Options.cs
+++ b/dotnet-openapi-generator/Options.cs
@@ -8,7 +8,7 @@ public class Options
     [Value(0, Required = true, HelpText = "Name of the project")]
     public string ProjectName { get; set; } = default!;
 
-    [Value(1, Required = true, HelpText = "Location of the swagger document. Can be both an http location or a local one")]
+    [Value(1, Required = true, HelpText = "Location of the JSON swagger document. Can be both an http location or a local one")]
     public string DocumentLocation { get; set; } = default!;
 
     [Option('n', "namespace", Required = false, HelpText = "(Default: Project name) The namespace used for the generated files")]

--- a/dotnet-openapi-generator/dotnet-openapi-generator.csproj
+++ b/dotnet-openapi-generator/dotnet-openapi-generator.csproj
@@ -56,6 +56,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(openapi-generator-version).0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="$(openapi-generator-version).0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="YamlDotNet" Version="13.7.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/dotnet-openapi-generator/dotnet-openapi-generator.csproj
+++ b/dotnet-openapi-generator/dotnet-openapi-generator.csproj
@@ -20,7 +20,7 @@
   -->
   
   <PropertyGroup Condition="'$(openapi-generator-version)' == ''">
-    <openapi-generator-version>7.0</openapi-generator-version>
+    <openapi-generator-version>8.0</openapi-generator-version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(openapi-generator-version-string)' == ''">

--- a/readme.md
+++ b/readme.md
@@ -17,27 +17,27 @@ Major and Minor version numbers always dictate the dotnet version being used.
 
 ### netstandard 2.0 generator installation
 ```bash
-dotnet tool install dotnet-openapi-generator -g --version 2.0.0-preview.13
+dotnet tool install dotnet-openapi-generator -g --version 2.0.0-preview.14
 ```
 
 ### netstandard 2.1 generator installation
 ```bash
-dotnet tool install dotnet-openapi-generator -g --version 2.1.0-preview.13
+dotnet tool install dotnet-openapi-generator -g --version 2.1.0-preview.14
 ```
 
 ### dotnet 5.0 generator installation
 ```bash
-dotnet tool install dotnet-openapi-generator -g --version 5.0.0-preview.13
+dotnet tool install dotnet-openapi-generator -g --version 5.0.0-preview.14
 ```
 
 ### dotnet 6.0 generator installation
 ```bash
-dotnet tool install dotnet-openapi-generator -g --version 6.0.0-preview.13
+dotnet tool install dotnet-openapi-generator -g --version 6.0.0-preview.14
 ```
 
 ### dotnet 7.0 generator installation
 ```bash
-dotnet tool install dotnet-openapi-generator -g --version 7.0.0-preview.13
+dotnet tool install dotnet-openapi-generator -g --version 7.0.0-preview.14
 ```
 
 
@@ -101,7 +101,7 @@ Steven Thuriot
 
   value pos. 0                       Required. Name of the project
 
-  value pos. 1                       Required. Location of the swagger document. Can be both an http location or a local one
+  value pos. 1                       Required. Location of the JSON swagger document. Can be both an http location or a local one
 ```
 
 ## Registration

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,12 @@ Steven Thuriot
 
   --json-derived-type-attribute      (Default: System.Text.Json.Serialization.JsonDerivedType(typeof({type}), typeDiscriminator: "{value}")) 
                                      Json Derived Type Attribute. Marks the derived types of the generated types using the specified attribute.
-                                     {type} and {value} are used as a template placeholders
+                                     {type} and {value} are used as template placeholders
+
+  --json-property-name-attribute     (Default: System.Text.Json.Serialization.JsonPropertyName("{name}"))
+                                     Json Property Name Attribute. Some property names are not valid in C#. This will make sure serialization works out.
+                                     {name} is used as a template placeholder
+
 
   -j, --json-source-generators       (Default: false) Include dotnet 7.0+ Json Source Generators
 

--- a/readme.md
+++ b/readme.md
@@ -40,12 +40,17 @@ dotnet tool install dotnet-openapi-generator -g --version 6.0.0-preview.14
 dotnet tool install dotnet-openapi-generator -g --version 7.0.0-preview.14
 ```
 
+### dotnet 8.0 generator installation
+```bash
+dotnet tool install dotnet-openapi-generator -g --version 8.0.0-preview.14
+```
+
 
 ## Getting started
 
 ```bash
 C:\Git > dotnet openapi-generator --help
-dotnet-openapi-generator 7.0.0-preview.13
+dotnet-openapi-generator 8.0.0-preview.14
 Steven Thuriot
 
   -n, --namespace                    (Default: Project name) The namespace used for the generated files


### PR DESCRIPTION
- Support dotnet 8.0
- Support non-standard enum values (e.g. `half-year` )
  - Newtonsoft ✅  (EnumMemberAttribute)
  - System.Text.Json ✅  (Custom converter)
  - Warning for any other libraries during generation that have been manually set by the user in their ClientOptions
- Fast compiled enum (de)serialization helpers
- Support non-standard propertynames (e.g. `0` )